### PR TITLE
Handle when public url ends with trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ module.exports = {
         log('Uploading sourcemaps to Rollbar', { verbose: true });
 
         var publicUrl = this.readConfig('publicUrl');
+        if (publicUrl.endsWith('/')) {
+          publicUrl = publicUrl.slice(0, -1)
+        }
 
         var promiseArray = [];
         var jsMapPairs = fetchJSMapPairs(distFiles, publicUrl, distDir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-rollbar-sourcemap",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ember-cli-deploy addon that uploads source maps to Rollbar's API",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Many of our ember applications have a trailing slash for their public urls. This is the what's handled for deploying specific git revisions to preview environments so we should handle it across environments